### PR TITLE
Changed URL protocol from HTTPS to HTTP in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [cfpb.github.io](https://cfpb.github.io/)
+# [cfpb.github.io](http://cfpb.github.io/)
 
 A site for the CFPB to share and discuss its technology work with the world.
 


### PR DESCRIPTION
The link in the README is pointing to https://cfpb.github.io/ which throws a certificate error.
