### PR TITLE
Add an RSS feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,7 @@ baseurl:     ''
 exclude:     [README.md, Gemfile, Gemfile.lock, vendor, _site]
 permalink:   /posts/:title
 pygments:    true
+
+title: CFPB Open Tech
+url: "http://cfpb.github.io"
+description: "Learn about the design and development work the Consumer Financial Protection Bureau undertakes to support its mission."

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,17 +2,19 @@
 <html>
 
 <head>
-    <meta http-equiv="content-type" content="text/html; charset=utf-8"> 
-    <title>CFPB Open Tech{% if page.title %} &ndash; {{ page.title }}{% endif %}</title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <title>{{ site.title }}{% if page.title %} &ndash; {{ page.title }}{% endif %}</title>
     {% if page.description %}
     <meta name="description" content="{{ page.description }}">
     {% else %}
-    <meta name="description" content="Learn about the design and development work the Consumer Financial Protection Bureau undertakes to support its mission.">
+    <meta name="description" content="{{ site.description }}">
     {% endif %}
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link rel="stylesheet" href="{% if page.assetpath %}{{ page.assetpath }}{% endif %}css/site.css">
+
+    <link rel="alternate" type="application/rss+xml" title="{{ site.name }} &raquo; Feed" href="/feed/" />
 
 <!--[if lt IE 9]>
     <link rel="stylesheet" href="{% if page.assetpath %}{{ page.assetpath }}{% endif %}css/ie8.css">

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,34 @@
+---
+layout: none
+permalink: /feed/
+json: false
+---
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+  xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+  >
+<channel>
+    <title xml:lang="en">{{ site.title}}</title>
+    <atom:link type="application/atom+xml" href="{{ site.url }}/feed/" rel="self"/>
+    <link>{{ site.url }}</link>
+    <pubDate>{{ site.time | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+    <lastBuildDate>{{ site.time | date: "%a, %d %b %Y %H:%M:%S %z" }}</lastBuildDate>
+    <language>en-US</language>
+    <description>{{ site.description }}</description>
+    {% for post in site.posts limit:site.rss_limit %}<item>
+        <title>{{ post.title }}</title>
+        <link>{{ site.url }}{{ post.url }}</link>
+        <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+        <dc:creator>{{ post.author }}</dc:creator>
+        {% for tag in post.tags %}<category>{{ tag | xml_escape }}</category>
+        {% endfor %}{% for cat in post.categories %}<category>{{ cat | xml_escape }}</category>
+        {% endfor %}<guid isPermaLink="false">{{ post.id }}</guid>
+        <description><![CDATA[ {{ post.content }} ]]></description>
+    </item>{% endfor %}
+</channel>
+</rss>


### PR DESCRIPTION
This also moves the site's `title` and `description` out into `_config.yml` so it can read via the `site` variable.

Adapted directly from @benbalter's approach in his own [Jekyll blog](https://github.com/benbalter/benbalter.github.com).
