### PR TITLE
Changing the link to our source code policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@ title: Home
                             </li>
                             <li class="learn-more_item">
                                 <a class="call-to-action"
-                                   href="https://github.com/cfpb/source-code-policy/blob/master/cfpb-source-code-policy.txt">
+                                   href="https://github.com/cfpb/source-code-policy/blob/gh-pages/cfpb-source-code-policy.txt">
                                     View our Source Code Policy
                                 </a>
                             </li>


### PR DESCRIPTION
Looks like our source code policy got moved to a different branch. Fixed the broken link.
