### PR TITLE
point to https url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "source-code-policy"]
 	path = source-code-policy
-	url = git://github.com/cfpb/source-code-policy.git
+	url = https://github.com/cfpb/source-code-policy.git


### PR DESCRIPTION
For some reason point to the `git` url now triggers a build error. This should fix that.
