### PR TITLE
Add IdeaBox page

### DIFF
--- a/ideabox/index.md
+++ b/ideabox/index.md
@@ -1,0 +1,33 @@
+---
+published: true
+layout: post
+author: 
+title: "IdeaBox"
+permalink: /ideabox/
+---
+
+IdeaBox aims to further the innovative and collaborative culture within the
+Consumer Financial Protection Bureau (CFPB) by harnessing the intellect and
+creativity of employees stationed across the country.
+It provides an online platform for all agency employees,
+regardless of level or geography,
+to share and build ideas on how to further the agency’s mission of
+improving the financial lives of consumers,
+as well as enhance the Bureau’s operations.
+The staff leading IdeaBox reviews the ideas for impact and feasibility,
+incubates the best ones into action plans,
+and navigates them through decision-making channels for possible implementation.
+
+IdeaBox was developed by the CFPB and is integrated into
+its open source intranet platform, Collab.
+Similar to other ideation platforms, IdeaBox allows users to
+share, like, tag, and comment on ideas.
+Users can also sort ideas by most liked, recently added, and trending,
+which is determined by recent likes or comments.
+Since launching nine months ago, the program has crowdsourced over 100 diverse
+ideas and incubated a range of solutions at varying levels of complexity.
+
+To learn more about how to replicate IdeaBox, check out a recording of our
+[webinar](http://www.digitalgov.gov/2014/11/03/cfpbs-ideabox-an-open-source-internal-ideation-platform/)
+on GSA’s DigitalGov and dive in to our openly-shared source code on
+[GitHub](https://github.com/cfpb/idea-box).


### PR DESCRIPTION
Context for this addition:

IdeaBox will soon be featured in a publication about
innovation in government. The press release is scheduled for
Wednesday, February 18th. That PR will include a link
directing people to https://cfpb.github.io/ideabox/ for more
information. This adds a page at that URL with a cleared
article describing the IdeaBox project.

Please talk to me directly if you have any questions.