### PR TITLE
Remove back end development job listings

### DIFF
--- a/jobs/automation-engineer/index.md
+++ b/jobs/automation-engineer/index.md
@@ -1,5 +1,5 @@
 ---
-published: true
+published: false
 layout: post
 author:
 title: "Back-end Developer (Automation Engineer)"

--- a/jobs/bewd/index.md
+++ b/jobs/bewd/index.md
@@ -1,5 +1,5 @@
 ---
-published: true
+published: false
 layout: post
 author:
 title: "Back-end Developer (BEWD)"

--- a/jobs/devops/index.md
+++ b/jobs/devops/index.md
@@ -1,5 +1,5 @@
 ---
-published: true
+published: false
 layout: post
 author:
 title: "Back-end Developer (DEVOPS)"

--- a/jobs/index.md
+++ b/jobs/index.md
@@ -1,5 +1,5 @@
 ---
-published: true
+published: false
 layout: post
 author:
 title: "Jobs"


### PR DESCRIPTION
This sets the published to false for the `/jobs/` page and each of the back end development job listings. Rather than remove them from the repo, I left them here in case we want to model future job listings after these.