### PR TITLE
Email

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@ title: Home
                                 <label class="recruit_fullname" for="recruit-name">
                                     Full Name
                                 </label>
-                                <input type="text" id="recruit-name" name="fullname">
+                                <input type="text" id="recruit-name" class="js-recruit-name" name="fullname">
                             </div>
                             <div class="recruit_chunk recruit_chunk__email">
                                 <label class="recruit_email" for="email">
@@ -277,7 +277,7 @@ title: Home
 
                             <a href="mailto:tech@cfpb.gov?subject=Interested in working in tech at CFPB&body=First name:%0D%0ALast name:%0D%0ADiscipline: %0D%0AResume:" class="btn btn-primary recruit_submit js-recruit-submit">Email Us</a>
 
-                            <p class="u-disclaimer"><small>The information you provide will permit the Consumer Financial Protection Bureau to process your request or inquiry. <a href="#privacy">See More</a></small></p>
+                            <p class="u-disclaimer"><small>The information you send to <a href="mailto:tech@cfpb.gov?subject=Interested in working in tech at CFPB">tech@cfpb.gov</a> will permit the Consumer Financial Protection Bureau to send you updates about future job openings. <a href="#privacy">See More</a></small></p>
                         </form>
                     </div>
                 </section>

--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@ title: Home
                                 <label class="recruit_email" for="email">
                                     Email
                                 </label>
-                                <input type="email" id="email" class="js-recruit-email" name="fullname">
+                                <input type="email" id="email" class="js-recruit-email" name="email">
                             </div>
 
                             <div class="recruit_chunk recruit_chunk__discipline">

--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@ title: Home
 
                             <div class="recruit_chunk recruit_chunk__discipline">
                                 <label class="recruit_discipline" for="discipline">
-                                    Select a discipline that matches your skillset the most
+                                    Select a discipline that best matches your skillset
                                 </label>
                                 <select id="discipline" name="discipline" class="js-recruit-discipline">
                                     <option value="">Choose one</option>

--- a/js/site.js
+++ b/js/site.js
@@ -14,8 +14,8 @@
               recruitEmail +
               '%0D%0A%0D%0ADiscipline: ' +
               discipline +
-              '%0D%0A%0D%0ABe sure to attach your resume ' +
-              'and remove this line before sending';
+              '%0D%0A%0D%0ANote: Attaching your resume can help us identify ' +
+              'openings you may be interested in.';
 
     window.location.href = url;
   } );


### PR DESCRIPTION
Reword email note and skillset line and fix capture of fullname

## Additions

- add class for full-name input so site.js can capture it for the email body
- exposes our email address so it can be copied by those not set up for mailto

## Changes

- Reword email note regarding resume
- Reword skillset line

## Deletions
- Awkward part of email note asking the user to delete the line. We can't ignore or delete the line on our end?

- @scotchester @jimmynotjim

## Screenshots
- What the sender sees  

<img width="489" alt="what_sender_sees" src="https://cloud.githubusercontent.com/assets/515885/12116444/d3b9d638-b387-11e5-8f6c-fcf04f6b5cf4.png">
