### PR TITLE
new URL for Complaint Database API Docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@ title: Home
                         <p class="featured-project_desc">View, sort, and analyze thousands of complaints. Download the data or build on it using our API.</p>
                         <div class="featured-project_links">
                             <a class="call-to-action" href="http://www.consumerfinance.gov/complaintdatabase/">Learn more</a> |
-                            <a class="call-to-action" href="http://www.consumerfinance.gov/complaintdatabase/technical-documentation/">API docs</a>
+                            <a class="call-to-action" href="http://cfpb.github.io/api/ccdb/">API docs</a>
                         </div>
                     </li>
                 </ul>


### PR DESCRIPTION
This updates the URL for the CCDB API docs to point to the Open Tech site. This can be merged after https://github.com/cfpb/api/pull/51 is merged + built.