### PR TITLE
Update link to eregs organization page

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ title: Home
                             <a class="call-to-action"
                                href="http://www.consumerfinance.gov/blog/making-regulations-easier-to-use/">
                                 Learn more</a> |
-                            <a class="call-to-action" href="https://cfpb.github.io/eRegulations/">
+                            <a class="call-to-action" href="https://eregs.github.io/">
                                 Project homepage</a>
                         </p>
                     </li>


### PR DESCRIPTION
The eRegs team has a joint organization page with 18F. This updates the link with the latest (and final) URL.