### PR TITLE
fix broken link for open source license

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,5 +91,5 @@ Interested in contributing to design discussions? Just check out the
 
 ## Open source licensing info
 1. [TERMS](TERMS.md)
-2. [LICENSE](LICENSE)
+2. [LICENSE](https://github.com/cfpb/source-code-policy/blob/gh-pages/LICENSE)
 3. [CFPB Source Code Policy](https://github.com/cfpb/source-code-policy/)


### PR DESCRIPTION
this links it to the license in your source-code-policy repo, though y'alls may prefer to place a copy of the license in this repo
