### PR TITLE
Create article archive page

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -48,7 +48,7 @@ assetpath: ../../
             <h2 class="sidebar_head">More articles</h2>
 
             <ul class="sidebar_list nav-list">
-            {% for post in site.posts limit:10 %}
+            {% for post in site.posts limit:5 %}
                 <li class="sidebar_list_item">
                     <h3 class="sidebar_list_item_head">
                         <a href="../../{{ post.url | remove_first:'/'}}">
@@ -71,11 +71,10 @@ assetpath: ../../
             {% endfor %}
             </ul>
 
-            <!-- Hide until we have published at least 4 articles -->
-            <!-- <a class="more-articles_read-more-link call-to-action__icon"
-               href="../../articles/">
-               Read more articles <i class="icon-right"></i>
-            </a> -->
+            <a class="call-to-action"
+               href="../">
+               View full archive
+            </a>
         </div>
     </section>
 </div>

--- a/articles/index.md
+++ b/articles/index.md
@@ -1,0 +1,31 @@
+---
+published: true
+layout: page
+author:
+title: "Article archive"
+permalink: /articles/
+---
+
+<ul class="nav-list">
+{% for post in site.posts %}
+    <li class="sidebar_list_item">
+        <h3 class="sidebar_list_item_head">
+            <a href="../../{{ post.url | remove_first:'/'}}">
+                {{ post.title }}
+            </a>
+        </h3>
+
+        <div class="sidebar_list_item_meta entry_meta">
+            {% if post.author %}
+            By <span class="author">{{ post.author }}</span> &ndash;
+            {% endif %}
+
+            {% if post.date %}
+            <time datetime="{{ post.date | date: '%b %d, %Y' }}">
+                {{ post.date | date: '%b %d, %Y' }}
+            </time>
+            {% endif %}
+        </div>
+    </li>
+{% endfor %}
+</ul>

--- a/index.html
+++ b/index.html
@@ -165,11 +165,10 @@ title: Home
                     {% endfor %}
                     </ul>
 
-                    <!-- Hide until we have published at least 4 articles -->
-                    <!-- <a class="more-articles_read-more-link call-to-action__icon"
+                    <a class="call-to-action"
                        href="articles/">
-                       Read more articles <i class="icon-right"></i>
-                    </a> -->
+                       View full archive
+                    </a>
                 </section>
             </section>
 


### PR DESCRIPTION
Creates a page at `/articles/` that lists all articles we've published, and adds links to that page in the appropriate places. Closes #52.

## Testing
1. Pull branch
2. `bundle install`
3. `bundle exec jekyll serve --baseurl ''`
4. Go to <http://localhost:4000/>
5. Click the "View full archive" link in the articles sidebar.

## Please review
- @willbarton 
- @ascott1