### PR TITLE
Updates for the cfpb.github.io homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@ title: Home
             </li>
             <li class="sidebar_list_item">
                 <h3 class="sidebar_list_item_head">
-                    <a href="https://github.com/cfpb/crawlsqueal">crawlsqueal</a>
+                    <a href="https://github.com/cfpb/crawsqueal">crawsqueal</a>
                     <i class="icon-external-link"></i>
                 </h3>
             </li>

--- a/index.html
+++ b/index.html
@@ -3,249 +3,154 @@ layout: default
 title: Home
 ---
 
-            <section class="hero">
-                <div class="wrap">
-                    <section class="intro">
-                        <h1>We'd like to share our work with you</h1>
-                        <p>The Consumer Financial Protection Bureau is a federal agency dedicated to ensuring that
-                            markets for consumer financial products and services are fair, transparent, and
-                            competitive. To support this mission, technologists at the CFPB build external
-                            resources for the public and internal tools to help the Bureau run more efficiently.
-                        </p>
-                        <ul class="learn-more">
-                            <li class="learn-more_item">
-                                <a class="call-to-action" href="articles/introducing-cfpb-open-tech/">
-                                    Learn more
-                                </a>
-                            </li>
-                            <li class="learn-more_item">
-                                <a class="call-to-action"
-                                   href="source-code-policy/">
-                                    View our Source Code Policy
-                                </a>
-                            </li>
-                        </ul>
-                    </section>
-                    <section class="sidebar">
-                        <h2 class="sidebar_head">Want to make a difference?</h2>
-                        <p>Join the CFPB and help us build a better financial future. Get in touch and we'll give you a heads up about relevant opportunities as they become available.</p>
-                        <a href="{{ site.mailing_list_url }}"class="btn btn-primary">Work with us</a>
-                    </section>
-                </div>
-            </section> <!-- /.hero -->
-
-            <section class="featured-projects">
-                <ul class="wrap nav-list">
-                    <li class="featured-project">
-                        <div class="featured-project_img__eregs"></div>
-                        <h3 class="featured-project_head">
-                            <a href="http://www.consumerfinance.gov/eregulations/">eRegulations</a>
-                        </h3>
-                        <p class="featured-project_desc">eRegulations is a web-based application that makes
-                            regulations easy to find, read, and understand.</p>
-                        <p class="featured-project_links">
-                            <a class="call-to-action"
-                               href="http://www.consumerfinance.gov/blog/making-regulations-easier-to-use/">
-                                Learn more</a> |
-                            <a class="call-to-action" href="https://eregs.github.io/">
-                                Project homepage</a>
-                        </p>
-                    </li>
-                    <li class="featured-project">
-                        <div class="featured-project_img__pdp"></div>
-                        <h3 class="featured-project_head">
-                            <a href="http://www.consumerfinance.gov/hmda/">Public Data Platform</a>
-                        </h3>
-                        <p class="featured-project_desc">Learn more about home mortgage data, download the data
-                            yourself, or build new tools using our API.</p>
-                        <div class="featured-project_links">
-                            <a class="call-to-action" href="https://github.com/cfpb/qu">GitHub repo</a> |
-                            <a class="call-to-action" href="http://cfpb.github.io/api/hmda/">API docs</a>
-                        </div>
-                    </li>
-                    <li class="featured-project">
-                        <div class="featured-project_img__ccdb"></div>
-                        <h3 class="featured-project_head">
-                            <a href="http://www.consumerfinance.gov/complaintdatabase/">Consumer Complaint Database</a>
-                        </h3>
-                        <p class="featured-project_desc">View, sort, and analyze thousands of complaints. Download the data or build on it using our API.</p>
-                        <div class="featured-project_links">
-                            <a class="call-to-action" href="http://www.consumerfinance.gov/complaintdatabase/">Learn more</a> |
-                            <a class="call-to-action" href="http://cfpb.github.io/api/ccdb/">API docs</a>
-                        </div>
-                    </li>
-                </ul>
-            </section>
-
-            <section class="articles wrap">
-                <h2 class="section-head"><i class="icon-document"></i> Articles</h2>
-
-                <section class="featured-entries">
-                {% for post in site.posts limit:1 %}
-                    <article class="entry">
-                        <h3 class="entry_title">
-                        {% if post.external-url %}
-                            <a href="{{ post.external-url }}">
-                        {% else %}
-                            <a href="{{ post.url | remove_first:'/'}}">
-                        {% endif %}
-                                {{ post.title }}
-                            </a>
-                        </h3>
-                        {% if post.tagline %}
-                        <p class="entry_tagline">{{ post.tagline }}</p>
-                        {% endif %}
-
-                        {% if post.excerpt %}
-                        <p class="entry_description">{{ post.excerpt | markdownify }}</p>
-                        {% endif %}
-
-                        <div class="entry_meta">
-                            {% if post.author %}
-                            By <span class="author">{{ post.author }}</span> &ndash;
-                            {% endif %}
-
-                            {% if post.date %}
-                            <time datetime="{{ post.date | date: '%b %d, %Y' }}">
-                                {{ post.date | date: '%b %d, %Y' }}
-                            </time>
-                            {% endif %}
-
-                            {% comment %}
-                                {% if post.tags %}
-                                <div class="tags cf">
-                                    <h4 class="tags_head">Tags:</h4>
-                                    <ul class="tag-list">
-                                        {% for tag in post.tags %}
-                                        <li class="tag">
-                                            <a class="tag_link">{{ tag }}</a>
-                                        </li>
-                                        {% endfor %}
-                                    </ul>
-                                </div>
-                                {% endif %}
-                            {% endcomment %}
-                        </div>
-<!--                      <a class="entry_read-more-link call-to-action__icon"
-                           href="{{ post.url | remove_first:'/'}}/">
-                           Read more <i class="icon-right"></i>
-                        </a> -->
-                    </article>
-                {% endfor %}
-                </section>
-
-                <section class="sidebar more-articles">
-                    <h2 class="sidebar_head">More articles</h2>
-
-                    <ul class="sidebar_list nav-list">
-                    {% for post in site.posts limit:3 offset:1 %}
-                        <li class="sidebar_list_item">
-                            <h3 class="sidebar_list_item_head">
-                            {% if post.external-url %}
-                                <a href="{{ post.external-url }}">
-                            {% else %}
-                                <a href="{{ post.url | remove_first:'/' }}">
-                            {% endif %}
-                                    {{ post.title }}
-                                </a>
-                            </h3>
-
-                            <div class="sidebar_list_item_meta entry_meta">
-                                {% if post.author %}
-                                By <span class="author">{{ post.author }}</span> &ndash;
-                                {% endif %}
-
-                                {% if post.date %}
-                                <time datetime="{{ post.date | date: '%b %d, %Y' }}">
-                                    {{ post.date | date: '%b %d, %Y' }}
-                                </time>
-                                {% endif %}
-                            </div>
-                        </li>
-                    {% endfor %}
-                    </ul>
-
-                    <a class="call-to-action"
-                       href="articles/">
-                       View full archive
+<section class="hero">
+    <div class="wrap">
+        <section class="intro">
+            <h1>We'd like to share our work with you</h1>
+            <p>The Consumer Financial Protection Bureau is a federal agency dedicated to ensuring that
+                markets for consumer financial products and services are fair, transparent, and
+                competitive. To support this mission, technologists at the CFPB build external
+                resources for the public and internal tools to help the Bureau run more efficiently.
+            </p>
+            <ul class="learn-more">
+                <li class="learn-more_item">
+                    <a class="call-to-action" href="articles/introducing-cfpb-open-tech/">
+                        Learn more
                     </a>
-                </section>
-            </section>
-
-            <section class="repositories wrap">
-                <h2 class="section-head"><i class="icon-github"></i> Repositories</h2>
-
-                <section class="repos">
-                    <section class="repo">
-                        <h3 class="repo_name"><a href="https://github.com/cfpb/idea-box">idea-box</a></h3>
-                        <p class="repo_description">An application that lets an organization collect ideas, comment on them, and vote them
-                            up.</p>
-                    </section>
-                    <section class="repo">
-                        <h3 class="repo_name"><a href="https://github.com/cfpb/ec2mapper">ec2mapper</a></h3>
-                        <p class="repo_description">EC2mapper is a web application that provides a user-friendly interface to view Amazon AWS
-                            network configurations, while allowing changes to be easily tracked over time.</p>
-                    </section>
-                    <section class="repo">
-                        <h3 class="repo_name"><a href="https://github.com/cfpb/transit_subsidy">transit_subsidy</a></h3>
-                        <p class="repo_description">Open source version of a simple Transit Subsidy intake form that is commonly used by United
-                            States federal government agencies. <i>Home of the first citizen pull request accepted by
-                            the U.S. government!</i></p>
-                    </section>
-                </section>
-
-                <section class="sidebar more-repos">
-                    <h2 class="sidebar_head">More repositories</h2>
-                    <ul class="sidebar_list nav-list">
-                        <li class="sidebar_list_item">
-                            <h3 class="sidebar_list_item_head">
-                                <a href="http://github.com/cfpb/django-nudge">django-nudge</a>
-                                <i class="icon-external-link"></i>
-                            </h3>
-                        </li>
-                        <li class="sidebar_list_item">
-                            <h3 class="sidebar_list_item_head">
-                                <a href="http://github.com/cfpb/django-cache-tools">django-cache-tools</a>
-                                <i class="icon-external-link"></i>
-                            </h3>
-                        </li>
-                        <li class="sidebar_list_item">
-                            <h3 class="sidebar_list_item_head">
-                                <a href="https://github.com/cfpb/hmda-tools">hmda-tools</a>
-                                <i class="icon-external-link"></i>
-                            </h3>
-                        </li>
-                    </ul>
-                    <a class="more-repos_view-all-link call-to-action__icon" href="https://github.com/cfpb">
-                        View all repositories <i class="icon-external-link"></i>
+                </li>
+                <li class="learn-more_item">
+                    <a class="call-to-action" href="source-code-policy/">
+                        View our Source Code Policy
                     </a>
-                </section>
-            </section>
+                </li>
+            </ul>
+        </section>
+        <section class="sidebar">
+            <h2 class="sidebar_head">Want to make a difference?</h2>
+            <p>Join the CFPB and help us build a better financial future. Get in touch and we'll give you a heads up
+                about relevant opportunities as they become available.</p>
+            <a href="{{ site.mailing_list_url }}" class="btn btn-primary">Work with us</a>
+        </section>
+    </div>
+</section> <!-- /.hero -->
 
-            <section class="work-at-cfpb wrap">
-                <h2 id="job-signup" class="section-head"><i class="icon-web"></i> Work with us</h2>
-                <section class="jobs">
-                    <div class="job-half">
-                        <p>
-                            Our mission demands smart, usable, and reliable technology.
-                            Come serve consumers by helping us design and build it.
-                        </p>
-                        <p>
-                            <a href="{{ site.mailing_list_url }}">Join our mailing list</a> to be notified when we post new jobs.
-                        </p>
-                        {% comment %}
-                        <p>We're currently looking for: </p>
-                        <ul>
-                            <li>
-                                <a href="https://cfpb.github.io/jobs/graphic-design/">Graphic Designer</a>
-                            </li>
-                        </ul>
-                        {% endcomment %}
-                        <p>
-                            Learn more about the work we do at our page for the
-                            <a href="http://www.consumerfinance.gov/jobs/technology-innovation-fellows/">Technology &amp; Innovation Fellowship</a>
-                            <i class="icon-external-link"></i>.
-                        </p>
-                    </div>
-                </section>
-            </section>
+<section class="featured-projects">
+    <ul class="wrap nav-list">
+        <li class="featured-project">
+            <div class="featured-project_img__eregs"></div>
+            <h3 class="featured-project_head">
+                <a href="http://www.consumerfinance.gov/">consumerfiance.gov</a>
+            </h3>
+            <p class="featured-project_desc">A Django project for protecting American consumers.</p>
+            <p class="featured-project_links">
+                <a class="call-to-action" href="https://github.com/cfpb/consumerfinance.gov">
+                    GitHub Repo</a> |
+                <a class="call-to-action" href="http://cfpb.github.io/consumerfinance.gov/">
+                    Project Docs</a>
+            </p>
+        </li>
+        <li class="featured-project">
+            <div class="featured-project_img__pdp"></div>
+            <h3 class="featured-project_head">
+                <a href="https://ffiec.cfpb.gov/">Home Mortage Disclosure Act</a>
+            </h3>
+            <p class="featured-project_desc">Online platform for financial instutions to maintain, report, and publicly
+                disclose information about mortgages.</p>
+            <div class="featured-project_links">
+                <a class="call-to-action" href="https://github.com/cfpb/hmda-platform">GitHub Repo</a> |
+                <a class="call-to-action" href="https://cfpb.github.io/hmda-platform/#hmda-api-documentation">API
+                    docs</a>
+            </div>
+        </li>
+        <li class="featured-project">
+            <div class="featured-project_img__ccdb"></div>
+            <h3 class="featured-project_head">
+                <a href="http://www.consumerfinance.gov/complaintdatabase/">Consumer Complaint Database</a>
+            </h3>
+            <p class="featured-project_desc">View, sort, and analyze thousands of complaints. Download the data or build
+                on it using our API.</p>
+            <div class="featured-project_links">
+                <a class="call-to-action" href="https://www.github.com/cfpb/ccdb5-api/">GitHub Repo</a> |
+                <a class="call-to-action" href="http://cfpb.github.io/api/ccdb5-api/">API docs</a>
+            </div>
+        </li>
+    </ul>
+</section>
+
+<section class="repositories wrap">
+    <h2 class="section-head"><i class="icon-github"></i> Repositories</h2>
+
+    <section class="repos">
+        <section class="repo">
+            <h3 class="repo_name"><a href="https://github.com/cfpb/django-flags">django-flags</a></h3>
+            <p class="repo_description">Allows users to toggle functionality in both Django code and the Django
+                templates
+                based on configurable conditions.</p>
+        </section>
+        <section class="repo">
+            <h3 class="repo_name"><a href="https://github.com/cfpb/design-system">design-system</a></h3>
+            <p class="repo_description">The CFPB's user interface framework and documenation hub.</p>
+        </section>
+        <section class="repo">
+            <h3 class="repo_name"><a href="https://github.com/cfpb/wagtail-inventory">wagtail-inventory</a></h3>
+            <p class="repo_description">Lets users search pages in their Wagtail site by the
+                StreamField block types they contain. </i></p>
+        </section>
+    </section>
+
+    <section class="sidebar more-repos">
+        <h2 class="sidebar_head">More repositories</h2>
+        <ul class="sidebar_list nav-list">
+            <li class="sidebar_list_item">
+                <h3 class="sidebar_list_item_head">
+                    <a href="http://github.com/cfpb/wagtail-flags">wagtail-flags</a>
+                    <i class="icon-external-link"></i>
+                </h3>
+            </li>
+            <li class="sidebar_list_item">
+                <h3 class="sidebar_list_item_head">
+                    <a href="http://github.com/cfpb/cfpb-chart-builder">cfpb-chart-builder</a>
+                    <i class="icon-external-link"></i>
+                </h3>
+            </li>
+            <li class="sidebar_list_item">
+                <h3 class="sidebar_list_item_head">
+                    <a href="https://github.com/cfpb/crawlsqueal">crawlsqueal</a>
+                    <i class="icon-external-link"></i>
+                </h3>
+            </li>
+        </ul>
+        <a class="more-repos_view-all-link call-to-action__icon" href="https://github.com/cfpb">
+            View all repositories <i class="icon-external-link"></i>
+        </a>
+    </section>
+</section>
+
+<section class="work-at-cfpb wrap">
+    <h2 id="job-signup" class="section-head"><i class="icon-web"></i> Work with us</h2>
+    <section class="jobs">
+        <div class="job-half">
+            <p>
+                Our mission demands smart, usable, and reliable technology.
+                Come serve consumers by helping us design and build it.
+            </p>
+            <p>
+                <a href="{{ site.mailing_list_url }}">Join our mailing list</a> to be notified when we post new jobs.
+            </p>
+            {% comment %}
+            <p>We're currently looking for: </p>
+            <ul>
+                <li>
+                    <a href="https://cfpb.github.io/jobs/graphic-design/">Graphic Designer</a>
+                </li>
+            </ul>
+            {% endcomment %}
+            <p>
+                Learn more about the work we do at our page for the
+                <a href="http://www.consumerfinance.gov/jobs/technology-innovation-fellows/">Technology &amp; Innovation
+                    Fellowship</a>
+                <i class="icon-external-link"></i>.
+            </p>
+        </div>
+    </section>
+</section>

--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@ title: Home
             </li>
             <li class="sidebar_list_item">
                 <h3 class="sidebar_list_item_head">
-                    <a href="http://github.com/cfpb/cfpb-chart-builder">cfpb-chart-builder</a>
+                    <a href="http://github.com/cfpb/cfpb-lighthouse">cfgov-lighthouse</a>
                     <i class="icon-external-link"></i>
                 </h3>
             </li>


### PR DESCRIPTION
These changes reflect the desire to make the cfpb.github.io page more "current".  The articles section has been removed and the highlighted projects and repos have been swapped out with more recent ones. 