### PR TITLE
Changed signup redirects to correct link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,4 +7,4 @@ title: CFPB Open Tech
 url: "https://cfpb.github.io/"
 description: "Learn about the technology work the Consumer Financial Protection Bureau undertakes to support its mission."
 
-mailing_list_url: "https://public.govdelivery.com/accounts/USCFPB/subscriber/new?topic_id=USCFPB_142"
+mailing_list_url: "https://public.govdelivery.com/accounts/USCFPB/signup/33293"


### PR DESCRIPTION
Previously, "Work with us" and "Join our mailing list" were linking to https://public.govdelivery.com/accounts/USCFPB/subscriber/new?topic_id=USCFPB_142 but now link to https://public.govdelivery.com/accounts/USCFPB/signup/33293

<img width="357" alt="image" src="https://user-images.githubusercontent.com/85513449/180472572-ce829c89-3f11-4fb8-9f87-e2a753055e2b.png">
