### PR TITLE
Build docker-compose functionality for easier set-up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,3 @@ WORKDIR /usr/src/app
 COPY . . 
 
 RUN bundle install
-
-RUN bundle add webrick
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,3 @@ RUN bundle install
 
 RUN bundle add webrick
 
-EXPOSE 4000
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby
+
+RUN gem install bundler -v 2.3.18
+
+WORKDIR /usr/src/app
+
+COPY . . 
+
+RUN bundle install
+
+RUN bundle add webrick
+
+EXPOSE 4000
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source 'https://rubygems.org'
 
-require 'json'
-require 'open-uri'
-versions = JSON.parse(open('https://pages.github.com/versions.json').read)
-
-gem 'github-pages', versions['github-pages']
+gem 'github-pages'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'github-pages'
+gem "webrick", "~> 1.7"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A site for the CFPB to share and discuss its technology work with the world.
 Content editors and developers probably want to set up cfpb.github.io on
 their local machine so they can preview updates without pushing to GitHub.
 
-Before you get started, make sure you have an up-to-date version of [Docker](https://www.docker.com/get-started/) installed on your machine and that is it is running.
+Before you get started, make sure you have an up-to-date version of [Docker](https://www.docker.com/get-started/) installed on your machine and that it is running.
 
 [Fork and clone the repo](https://help.github.com/articles/fork-a-repo/)
 to your local machine.

--- a/README.md
+++ b/README.md
@@ -2,44 +2,19 @@
 
 A site for the CFPB to share and discuss its technology work with the world.
 
-## Running it locally
+## Running it locally with Docker
 
 Content editors and developers probably want to set up cfpb.github.io on
 their local machine so they can preview updates without pushing to GitHub.
 
-Before you get started make sure you have an up-to-date version of Ruby and Bundler.
-We use [Homebrew](http://brew.sh/):
-
-```sh
-brew install ruby
-gem install bundler
-```
-
-As the site is intended to be deployed on GitHub Pages, installing the
-GitHub Pages gem is the best way to install Jekyll and related dependencies.
-Run the following command to install it:
-
-```sh
-bundle install
-```
-
-**Note:** As of 6/23/16, you may need to run this command before running
-`bundle install` to handle a bug in one of the dependencies:
-
-```sh
-bundle config build.nokogiri --use-system-libraries
-```
+Before you get started, make sure you have an up-to-date version of [Docker](https://www.docker.com/get-started/) installed on your machine and that is it is running.
 
 [Fork and clone the repo](https://help.github.com/articles/fork-a-repo/)
 to your local machine.
 
-From the project directory, run Jekyll:
+From the project directory, run `docker-compose up`. 
 
-```sh
-bundle exec jekyll serve --watch
-```
-
-Open it up in your browser: <http://localhost:4000/>
+Open it up in your browser: [http://localhost:4000/](http://localhost:4000/)
 
 
 ## Working with the front end

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Before you get started, make sure you have an up-to-date version of [Docker](htt
 [Fork and clone the repo](https://help.github.com/articles/fork-a-repo/)
 to your local machine.
 
-From the project directory, run `docker-compose up`. 
+Using terminal, in the project directory, run:
+```sh
+docker-compose up
+``` 
 
 Open it up in your browser: [http://localhost:4000/](http://localhost:4000/)
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,5 +5,7 @@ services:
     build: .
     container_name: cfpb-io-container
     command: bundle exec jekyll serve --host 0.0.0.0
+    volumes:
+      - .:/usr/src/app
     ports:
       - "4000:4000"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: '3'
+
+services:
+  web:
+    build: .
+    container_name: cfpb-io-container
+    command: bundle exec jekyll serve --watch
+    ports:
+      - "4000:4000"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,6 @@ services:
   web:
     build: .
     container_name: cfpb-io-container
-    command: bundle exec jekyll serve --watch
+    command: bundle exec jekyll serve --host 0.0.0.0
     ports:
       - "4000:4000"


### PR DESCRIPTION
This PR includes the mechanics for using docker-compose to get the application up and running.  

Aside from adding the `Dockerfile` and `docker-compose.yaml`, changes were made to the `.Gemfile`. I removed the requirements for `json` and `uni-open`, and added in a new gem for `webrick` (please see [this similar GitHub issue](https://github.com/jekyll/jekyll/issues/8523) for why I did that).  Removing `json` and `uni-open` did not impair functionality and I am hoping that someone can clarify whether or not they are, indeed, _required._  



The reason they were removed is due to this error:

`#10 3.745 [!] There was an error parsing `Gemfile`: No such file or directory @ rb_sysopen - https://pages.github.com/versions.json. Bundler cannot continue.
#10 3.745 
#10 3.745  #  from /usr/src/app/Gemfile:6
#10 3.745  #  -------------------------------------------
#10 3.745  #  require 'open-uri'
#10 3.745  >  versions = JSON.parse(open('https://pages.github.com/versions.json').read)
#10 3.745  #  
#10 3.745  #  -------------------------------------------`

It appears, based off of [this intel](https://github.com/rubygems/bundler/issues/6154), that there is an issue with jekyll and gem building inside a docker container due to environmental variable confusions.  Please note, I did attempt numerous solutions that I stumbled across and none of them eradicated the error or constructed a functional container.   Thus, I removed, and everything appears to be running smoothly.

Moreover, I re-wrote the instructions for the `README.md`.  I am unsure if they are too vague/need to be more detailed?   The reason I removed the previous ones is because they didn't work on my CFPB Mac.  