### PR TITLE
Fix links to CCDB and its API documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,13 +65,13 @@ title: Home
         <li class="featured-project">
             <div class="featured-project_img__ccdb"></div>
             <h3 class="featured-project_head">
-                <a href="http://www.consumerfinance.gov/complaintdatabase/">Consumer Complaint Database</a>
+                <a href="http://www.consumerfinance.gov/data-research/consumer-complaints/">Consumer Complaint Database</a>
             </h3>
             <p class="featured-project_desc">View, sort, and analyze thousands of complaints. Download the data or build
                 on it using our API.</p>
             <div class="featured-project_links">
                 <a class="call-to-action" href="https://www.github.com/cfpb/ccdb5-api/">GitHub Repo</a> |
-                <a class="call-to-action" href="http://cfpb.github.io/api/ccdb5-api/">API docs</a>
+                <a class="call-to-action" href="http://cfpb.github.io/api/ccdb/">API docs</a>
             </div>
         </li>
     </ul>


### PR DESCRIPTION
The link to the CCDB API documentation was confused between the cfpb/api and the cfpb/ccdb5-api repos. 
The Consumer Response docs are at cfpb/api/ccdb.

Also, a link to the CCDB landing page worked, with a redirect, but we can save a hop by linking to the target page.