### PR TITLE
README: suggest `docker compose`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ to your local machine.
 
 Using terminal, in the project directory, run:
 ```sh
-docker-compose up
+docker compose up
 ``` 
 
 Open it up in your browser: [http://localhost:4000/](http://localhost:4000/)


### PR DESCRIPTION
Since it is suggested that users have an up-to-date version of docker, update the suggested command to reflect the docker recommendation for Compose V2. See https://docs.docker.com/compose/releases/migrate/